### PR TITLE
Update providers and terraform versions settings

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,21 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
-
+  required_version = ">= 0.12"
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## what
* Update terraform and provider version requirements

## why
* 3.0 AWS provider is already here and we should be able to use the module with it


